### PR TITLE
fix-keychain-create

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,26 @@ provided via `-Password` parameter otherwise you will be prompted at the console
 
 The specific keychain created for PowerShell will require you to enter a password twice. If you forget this password, it can be reset with `Set-KeyChainConfiguration`.
 
-```powershell
-Register-SecretVault -Name KeyChain -Module SecretManagement.KeyChain
-Get-KeyChainConfiguration (new keychain will be created in this step)
-(optional) Set-KeyChainConfiguration -PasswordTimeout <int>
+```console
+PS> Register-SecretVault -Name KeyChain -Module SecretManagement.KeyChain
 
-Set-Secret -Name justask -Vault KeyChain
+# new keychain will be created in next step
+PS> Get-KeyChainConfiguration
+
+# optional if you want to change the default timeout of 300 seconds
+PS> Set-KeyChainConfiguration -PasswordTimeout <int>
+
+PS> Set-Secret -Name justask -Vault KeyChain
 cmdlet Set-Secret at command pipeline position 1
 Supply values for the following parameters:
 SecureStringSecret: ***************
 
-Get-SecretInfo -Vault KeyChain
+PS> Get-SecretInfo -Vault KeyChain
 Name            Type VaultName
 ----            ---- ---------
 justask SecureString KeyChain
 
-Get-Secret -Name justask -Vault KeyChain -AsPlainText
+PS> Get-Secret -Name justask -Vault KeyChain -AsPlainText
 ```
 
 ## Module Design

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ These cmdlets are exported by this module for use by the user:
 
 ### Get-KeyChainConfiguration
 
-Returns the current configuration for the specific KeyChain used by this module:
+Returns the current configuration for the specific KeyChain used by this module. If the `SecretManagement.KeyChain` has not been created, you will be prompted for a new password specifically for this key-chain.
 
 ```powershell-output
 PS> Get-KeyChainConfiguration
@@ -26,6 +26,28 @@ Set the timeout for the password.  Default is 300 seconds.  Set to 0 for no-time
 
 Allows programmatic ability to unlock KeyChain if there is a timeout set for automation.  Password needs to be
 provided via `-Password` parameter otherwise you will be prompted at the console.
+
+## Configuration of SecretManagement.KeyChain
+
+The specific keychain created for PowerShell will require you to enter a password twice. If you forget this password, it can be reset with `Set-KeyChainConfiguration`.
+
+```powershell
+Register-SecretVault -Name KeyChain -Module SecretManagement.KeyChain
+Get-KeyChainConfiguration (new keychain will be created in this step)
+(optional) Set-KeyChainConfiguration -PasswordTimeout <int>
+
+Set-Secret -Name justask -Vault KeyChain
+cmdlet Set-Secret at command pipeline position 1
+Supply values for the following parameters:
+SecureStringSecret: ***************
+
+Get-SecretInfo -Vault KeyChain
+Name            Type VaultName
+----            ---- ---------
+justask SecureString KeyChain
+
+Get-Secret -Name justask -Vault KeyChain -AsPlainText
+```
 
 ## Module Design
 

--- a/src/SecretManagement.KeyChain/SecretManagement.KeyChain.psd1
+++ b/src/SecretManagement.KeyChain/SecretManagement.KeyChain.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion = '0.1.2'
+    ModuleVersion = '0.1.3'
     CompatiblePSEditions = @('Core')
     GUID = '74bb5212-2a5d-451d-8f43-edf9bcd2efe8'
     Author = 'Steve Lee'


### PR DESCRIPTION
Fix logic in Test-SecretVault that detects keychain needs to be created. Added verbose output to this cmdlet & README content to describe first use of extension.