### PR TITLE
The big bear fix keychain setup

### DIFF
--- a/src/SecretManagement.KeyChain/SecretManagement.KeyChain.Extension/SecretManagement.KeyChain.Extension.psd1
+++ b/src/SecretManagement.KeyChain/SecretManagement.KeyChain.Extension/SecretManagement.KeyChain.Extension.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'SecretManagement.KeyChain.Extension.psm1'
-    ModuleVersion = '0.1.1'
+    ModuleVersion = '0.1.4'
     CompatiblePSEditions = @('Core')
     GUID = '6a4caa73-b31c-4df3-a751-9b96b1daf294'
     Author = 'Steve Lee'

--- a/src/SecretManagement.KeyChain/SecretManagement.KeyChain.Extension/SecretManagement.KeyChain.Extension.psm1
+++ b/src/SecretManagement.KeyChain/SecretManagement.KeyChain.Extension/SecretManagement.KeyChain.Extension.psm1
@@ -199,7 +199,7 @@ function Set-Secret {
     )
 
     $VaultName = Get-VaultName $VaultName
-    Test-SecretVault -VaultName $VaultName
+    Test-SecretVault -Name $VaultName
 
     # KeyChain is case-sensitive, so always use lowercase
     $Name = $Name.ToLower()

--- a/src/SecretManagement.KeyChain/SecretManagement.KeyChain.psd1
+++ b/src/SecretManagement.KeyChain/SecretManagement.KeyChain.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion = '0.1.3'
+    ModuleVersion = '0.1.4'
     CompatiblePSEditions = @('Core')
     GUID = '74bb5212-2a5d-451d-8f43-edf9bcd2efe8'
     Author = 'Steve Lee'

--- a/src/SecretManagement.KeyChain/SecretManagement.KeyChain.psm1
+++ b/src/SecretManagement.KeyChain/SecretManagement.KeyChain.psm1
@@ -38,7 +38,7 @@ function Get-KeyChainConfiguration {
     [CmdletBinding()]
     param ()
 
-    $null = Test-SecretVault -VaultName $keyChainName
+    $null = Test-SecretVault -Name $keyChainName
     $out = & $securityCmd show-keychain-info $keyChainName 2>&1
 
     # example output:


### PR DESCRIPTION
the Test-SecretVault param for VaultName has been changed from ```-VaultName``` to simply ```-Name``` and the modules version has bee increased to 0.1.3

